### PR TITLE
Update parse.py

### DIFF
--- a/suricataparser/parse.py
+++ b/suricataparser/parse.py
@@ -4,8 +4,8 @@ from suricataparser.exceptions import RuleParseException
 from suricataparser.rule import Rule, Option, Metadata
 
 
-rule_pattern = re.compile(r"^(?P<enabled>#)*[\s#]*"
-                          r"(?P<raw>"
+rule_pattern = re.compile(r"(?P<raw>"
+                          r"^(?P<enabled>#)*[\s#]*"
                           r"(?P<header>[^()]+)"
                           r"\((?P<options>.*)\)"
                           r"$)")


### PR DESCRIPTION
Switched the group order for rule_pattern, so that the group "raw" is processed with the preceeding #. In the previous order, a disabled rule would not be commented out in the "raw" rule string, and would have to be added manually.